### PR TITLE
Avoid dynamic part from sender_id on emission deferred transaction #852

### DIFF
--- a/golos.emit/abi/golos.emit.abi
+++ b/golos.emit/abi/golos.emit.abi
@@ -65,7 +65,6 @@
             "fields": [
                 {"type": "uint64", "name": "id"},
                 {"type": "uint64", "name": "prev_emit"},
-                {"type": "uint128", "name": "tx_id"},
                 {"type": "uint64", "name": "start_time"},
                 {"type": "bool", "name": "active"}
             ]

--- a/golos.emit/include/golos.emit/golos.emit.hpp
+++ b/golos.emit/include/golos.emit/golos.emit.hpp
@@ -11,7 +11,6 @@ using namespace eosio;
 
 struct [[eosio::table]] state {
     uint64_t prev_emit;
-    uint128_t tx_id;
     uint64_t start_time;
     bool active;
 };
@@ -39,7 +38,7 @@ private:
         return cfg;
     }
 
-    void schedule_next(state& s, uint32_t delay);
+    void schedule_next(uint32_t delay);
 };
 
 } // golos

--- a/tests/golos.emit_tests.cpp
+++ b/tests/golos.emit_tests.cpp
@@ -79,19 +79,18 @@ BOOST_FIXTURE_TEST_CASE(start_emission_test, golos_emit_tester) try {
     BOOST_TEST_MESSAGE("--- started");
     produce_block();    // `emit` being processed in next tx (deferred), go next block to be sure state updated
     auto obj_params = emit.get_params();
-    auto t = emit.get_state();
-    auto tx = t["tx_id"];
+    auto t1 = emit.get_state()["prev_emit"];
 
     BOOST_TEST_MESSAGE("--- go to block just before emission");
     auto emit_interval = obj_params["interval"]["value"].as<uint16_t>() * 1000 / cfg::block_interval_ms;
     produce_blocks(emit_interval - 1);      // actually we go to emission block now; TODO: resolve, why deferred tx sometimes applied before get_state() and sometimes we need to go next block
-    BOOST_CHECK_EQUAL(tx, emit.get_state()["tx_id"]);
+    BOOST_CHECK_EQUAL(t1, emit.get_state()["prev_emit"]);
     BOOST_TEST_MESSAGE("--- next block, check emission");
     produce_block();
-    auto tx2 = emit.get_state()["tx_id"];
-    BOOST_CHECK_NE(tx, tx2);
+    auto t2 = emit.get_state()["prev_emit"];
+    BOOST_CHECK_NE(t1, t2);
     produce_block();
-    BOOST_CHECK_EQUAL(tx2, emit.get_state()["tx_id"]);
+    BOOST_CHECK_EQUAL(t2, emit.get_state()["prev_emit"]);
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(set_params, golos_emit_tester) try {


### PR DESCRIPTION
Resolve #852 
- Schedule emit with constant sender_id
- Remove trx_id from emit state